### PR TITLE
Create an instance of Partitioner before calling .call

### DIFF
--- a/lib/fluent/plugin/kafka_producer_ext.rb
+++ b/lib/fluent/plugin/kafka_producer_ext.rb
@@ -250,7 +250,7 @@ module Kafka
 
         begin
           if partition.nil?
-            partition = Partitioner.call(partition_count, message)
+            partition = Partitioner.new.call(partition_count, message)
           end
 
           @buffer.write(


### PR DESCRIPTION
I think this fixes the problem better than before.